### PR TITLE
Deployment fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN yum makecache && yum install -y \
   git \
   java-1.7.0-openjdk \
   postgresql-jdbc \
+  sendmail \
   tar \
   unzip \
   zip \


### PR DESCRIPTION
Caso o utilizador que iniciou o docker tenha um User ID diferente de 1000, dentro do docker container não se conseguem alterar os ficheiros (nao tem permissões porque o User ID e o Group ID sao diferentes).

O UID é a parte mais importante, e meti 1000 por predefinição que corresponde ao primeiro utilizador (sem ser root). O GID só é verificado se o UID não for o dono do ficheiro, que definindo o UID correctamente, nunca é necessário.
