### PR TITLE
Tenta usar os prefixes definidos na ontologia

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -182,7 +182,7 @@ class QueriesController < ApplicationController
 
     # Get ontology from the URL
     def get_ontology
-      @ontology = Ontology.where(code: params[:ontology_code]).first
+      @ontology = Ontology.eager_load(:prefixes).where(code: params[:ontology_code]).first
     end
 
     # Auxiliar Method

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -18,8 +18,9 @@ module QueriesHelper
   def oclude(input)
     text = namespace(input)
     res = nil
+    #search the prefixes of this ontology
     @ontology.prefixes.each do |x|
-        res = x.name if x.uri.include? text
+      res = x.name if x.uri.include? text
     end
     if res == nil or res == ""
       res = text.rpartition('/').last


### PR DESCRIPTION
Tenta usar os prefixos definidos na ontologia para calcular os namespaces.
Se não conseguir usa o método que era usado antes.
Também mudei de '#' para ':' entre o namespace e o id da instância.
